### PR TITLE
Update devex-cli.rb to set openjdk to v17

### DIFF
--- a/Formula/devex-cli.rb
+++ b/Formula/devex-cli.rb
@@ -10,7 +10,7 @@ class DevexCli < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  depends_on "openjdk"
+  depends_on "openjdk@17"
 
   conflicts_with "miguelaferreira/tools/devex-cli-native-binary", because: "it also ships a devex executable"
 


### PR DESCRIPTION
This PR updates the devex-cli formula dependency on openjdk to pin it to version 17.