### PR TITLE
Fail native-binary install on macOS amd64 with a clear message

### DIFF
--- a/Formula/devex-cli-native-binary.rb
+++ b/Formula/devex-cli-native-binary.rb
@@ -14,6 +14,19 @@ class DevexCliNativeBinary < Formula
 
     os = OS.mac? ? "macOS" : "Linux"
     arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+
+    # No native binary is built for macOS on Intel (amd64): the release matrix
+    # ships Linux amd64, Linux arm64, and macOS arm64 only. Fail early with a
+    # clear message instead of a confusing missing-file error from shasum.
+    if OS.mac? && arch == "amd64"
+      odie <<~EOS
+        devex-cli does not ship a native binary for macOS on Intel (amd64).
+        Supported native targets are macOS arm64, Linux amd64, and Linux arm64.
+        On an Intel Mac, install the JVM formula instead:
+          brew install miguelaferreira/tools/devex-cli
+      EOS
+    end
+
     binary = "devex-#{os}-#{arch}-v#{version}"
     system "shasum", "-c", "#{binary}.sha256sum"
     mv binary, "devex"


### PR DESCRIPTION
## What

The `devex-cli-native-binary` formula only checked the OS (`OS.mac? || OS.linux?`), not the OS+arch combination. Since the devex-cli release matrix dropped the macOS amd64 build (it now ships **Linux amd64, Linux arm64, macOS arm64**), an Intel Mac resolves `arch = amd64` and builds `devex-macOS-amd64-v...`, which does not exist. Install then dies at `shasum -c` with a confusing "No such file" error.

## Change

Add an explicit guard that `odie`s on the unbuilt macOS+amd64 combination, explaining the supported targets and pointing Intel-Mac users at the JVM formula (`miguelaferreira/tools/devex-cli`).

`update-formula.sh` only sed-replaces version/sha256, so the release automation will not disturb this guard. Verified with `ruby -c`.